### PR TITLE
Add colors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ SRCS	=	sources/parsing/parsing_utils.c 	\
 			sources/mlx_utils/get_pixel.c		\
 			sources/mlx_utils/put_img_to_img.c	\
 			sources/mlx_utils/img_create.c		\
+			sources/colors/clr_make_trgb.c		\
+			sources/colors/clr_get.c			\
 			sources/init.c
 
 NAME	=	cub3D

--- a/includes/colors.h
+++ b/includes/colors.h
@@ -1,0 +1,40 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   colors.h                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/18 18:44:58 by lray              #+#    #+#             */
+/*   Updated: 2023/12/19 02:31:51 by lray             ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef COLORS_H
+# define COLORS_H
+
+# define CLR_BLACK		0x00000000U
+# define CLR_GRAY		0x00808080U
+# define CLR_LIGHT_GRAY	0x00C0C0C0U
+# define CLR_DARK_GRAY	0x00404040U
+# define CLR_WHITE		0x11111111U
+# define CLR_RED		0x00FF0000U
+# define CLR_ORANGE		0x00FFA500U
+# define CLR_YELLOW		0x00FFFF00U
+# define CLR_GREEN		0x0000FF00U
+# define CLR_BLUE		0x000000FFU
+# define CLR_INDIGO		0x004B0082U
+# define CLR_VIOLET		0x008000FFU
+# define CLR_CYAN		0x0000FFFFU
+# define CLR_MAGENTA	0x00FF00FFU
+# define CLR_PURPLE		0x00800080U
+# define CLR_BROWN		0x00A52A2AU
+
+
+int				clr_make_trgb(unsigned char t, unsigned char r, unsigned char g, unsigned char b);
+unsigned char	clr_get_t(int trgb);
+unsigned char	clr_get_r(int trgb);
+unsigned char	clr_get_g(int trgb);
+unsigned char	clr_get_b(int trgb);
+
+#endif

--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -13,6 +13,7 @@
 
 #include "structures.h"
 #include "mlx_utils.h"
+#include "colors.h"
 
 typedef struct s_mlx_data
 {

--- a/sources/colors/clr_get.c
+++ b/sources/colors/clr_get.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   clr_get.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/19 02:07:46 by lray              #+#    #+#             */
+/*   Updated: 2023/12/19 02:12:23 by lray             ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/cub3d.h"
+
+unsigned char	clr_get_t(int trgb)
+{
+	return (((unsigned int *)&trgb)[3]);
+}
+
+unsigned char	clr_get_r(int trgb)
+{
+	return (((unsigned int *)&trgb)[2]);
+}
+
+unsigned char	clr_get_g(int trgb)
+{
+	return (((unsigned int *)&trgb)[1]);
+}
+
+unsigned char	clr_get_b(int trgb)
+{
+	return (((unsigned int *)&trgb)[0]);
+}
+

--- a/sources/colors/clr_make_trgb.c
+++ b/sources/colors/clr_make_trgb.c
@@ -1,0 +1,18 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   clr_make_trgb.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/18 18:46:15 by lray              #+#    #+#             */
+/*   Updated: 2023/12/18 18:52:16 by lray             ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/cub3d.h"
+
+int	clr_make_trgb(unsigned char t, unsigned char r, unsigned char g, unsigned char b)
+{
+	return (*(int *)(unsigned char [4]){b, g, r, t});
+}


### PR DESCRIPTION
This command lets you manage the colors of the `MLX`.  To differentiate these functions, I've chosen the prefix `clr`.

## clr_make_trgb()
This function returns an `int` in `trgb` format from 4 `unsigned int` (*transparent*, *red*, *green*, *blue*). Each parameter has 256 possibilities ranging from 0 to 255.

This function will be very useful, for example, to transform colors entered by the user in the configuration file, into colors understood by the `MLX`.

We absolutely must be consistent in our program when it comes to the form in which we store our colors in memory. The best solution is to convert them all to `trgb` format as soon as possible and store them in this form.

## clr_get_*

- `clr_get_t()`
- `clr_get_r()`
- `clr_get_g()`
- `clr_get_b()`

These 4 functions are very similar. They return the value (t, r, g, or b) of a color `trgb`.